### PR TITLE
修复一处翻译错误.

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -526,7 +526,7 @@ Laravel 也提供了多种有用的工具来让你更容易的测试使用数据
 
 #### 保存工厂模型
 
-你不仅可使用 `create` 方法来创建模型实例，而且也可以使用 Eloquent 的 `save` 方法来将它们保存至数据库：
+`create` 方法不仅会创建模型实例, 同时也会将模型实例(通过调用 Eloquent 的 `save` 方法)保存至数据库. 
 
     public function testDatabase()
     {


### PR DESCRIPTION
原文: 
The create method not only creates the model instances, but also saves them to the database using Eloquent's save method

现在错误的翻译:
你不仅可使用 create 方法来创建模型实例，而且也可以使用 Eloquent 的 save 方法来将它们保存至数据库

正确的翻译应当为:
`create` 方法不仅会创建模型实例, 同时也会将模型实例(通过调用 Eloquent 的 `save` 方法)保存至数据库.