### PR TITLE
Revert 「完成 邮件 及 社会化登录 的翻译工作」

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -83,40 +83,6 @@ Gates 也可以使用 `Class@method` 形式作为回调字符串，比如控制�
         'posts.image' => 'updateImage',
     ]);
 
-Gates 也可以使用 `Class@method` 风格的回调字符串来定义，比如控制器:
-
-    /**
-     * Register any authentication / authorization services.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        $this->registerPolicies();
-
-        Gate::define('update-post', 'PostPolicy@update');
-    }
-
-#### 资源 Gates
-
-你还可以使用 `resource` 方法一次性定义多个 Gate 功能:
-
-    Gate::resource('posts', 'PostPolicy');
-
-这与手动编写以下 Gate 定义相同：
-
-    Gate::define('posts.view', 'PostPolicy@view');
-    Gate::define('posts.create', 'PostPolicy@create');
-    Gate::define('posts.update', 'PostPolicy@update');
-    Gate::define('posts.delete', 'PostPolicy@delete');
-
-默认情况下将会定义 `view` ， `create` ， `update` ，和 `delete` 功能。 通过将数组作为第三个参数传递给 `resource` 方法，您可以覆盖或添加新功能到默认的功能。 数组的键定义能力的名称，而值定义方法名称。 例如，以下代码将创建两个新的Gate定义： `posts.image` 和 `posts.photo` ：
-
-    Gate::resource('posts', 'PostPolicy', [
-        'image' => 'updateImage',
-        'photo' => 'updatePhoto',
-    ]);
-
 <a name="authorizing-actions-via-gates"></a>
 ### 使用 gates 授权动作
 

--- a/mail.md
+++ b/mail.md
@@ -13,7 +13,6 @@
     - [生成 Markdown 格式的邮件](#generating-markdown-mailables)
     - [编写 Markdown 格式的邮件](#writing-markdown-messages)
     - [自定义组件](#customizing-the-components)
-    - [在浏览器中预览邮件](#previewing-mailables-in-the-browser)
 - [发送邮件](#sending-mail)
     - [队列邮件](#queueing-mail)
 - [邮件与本地开发](#mail-and-local-development)
@@ -395,17 +394,6 @@ Markdown mailables 使用 Blade 组件和 Markdown 语法的组合，允许你�
 在导出组件之后，`resources/views/vendor/mail/html/themes` 文件夹将包含一个默认的 `default.css` 文件。你可以在这个文件中自定义 CSS ，你定义的这些样式将会在 Markdown 格式消息体转换成 HTML 格式时自动得到应用。
 
 > {tip} 如果你想为 Markdown 组件构建一个全新的主题，只要写一个新的 CSS 文件，放在 `html/themes` 文件夹，然后在你的 `mail` 配置文件中改变 `theme` 选项就可以了。
-
-<a name="previewing-mailables-in-the-browser"></a>
-## 在浏览器中预览邮件
-
-当你设计一个邮件模板时，可以很方便地在浏览器中快速预览渲染出来的邮件，就像典型的 Blade 模板一样。为此， Laravel 允许你直接从路由闭包或者控制器中返回任何的邮件。当邮件被返回时，他会被渲染并显示在浏览器中，允许你快速预览其设计，而不必发送到实际的电子邮件地址。
-
-    Route::get('/mailable', function () {
-        $invoice = App\Invoice::find(1);
-
-        return new App\Mail\InvoicePaid($invoice);
-    });
 
 <a name="sending-mail"></a>
 ## 发送邮件

--- a/socialite.md
+++ b/socialite.md
@@ -18,8 +18,6 @@ Laravel 社会化登录通过 Facebook ， Twitter ，Google ，LinkedIn ，GitH
 
 **我们不接受新的适配器。**
 
-**如果你使用 Laravel 5.3 或更低版本，请使用 [Socialite 2.0](https://github.com/laravel/socialite/tree/2.0)。**
-
 社区驱动的社会化登录提供商网站上可以找到为其他平台提供的适配器列表。
 
 <a name="license"></a>
@@ -102,18 +100,11 @@ class LoginController extends Controller
 }
 ```
 
- `redirect` 方法负责发送用户到 OAuth 提供商，而 `user` 方法将读取传入的请求并从提供商处检索用户信息。在重定向用户之前，你还可以加入附加的 `scope` 方法来设置请求的「scope」。这个方法会覆盖所有现有的范围。
+ `redirect` 方法负责发送用户到 OAuth 提供商，而 `user` 方法将读取传入的请求并从提供商处检索用户信息。在重定向用户之前，你还可以使用 `scope` 方法来设置请求的「scope」。这个方法会覆盖所有现有的范围。
  
 ```php
 return Socialite::driver('github')
             ->scopes(['scope1', 'scope2'])->redirect();
-```
-
-你可以使用 `setScopes` 方法覆盖所有已经存在的 scopes：
-
-```php
-return Socialite::driver('github')
-            ->setScopes(['scope1', 'scope2'])->redirect();
 ```
 
 当然，你需要定义通往你的控制器方法的路由。


### PR DESCRIPTION
此 PR 误将 5.5 新增功能合并入了 5.4 分支，污染了[线上 5.4 文档](https://d.laravel-china.org/docs/5.4/mail#previewing-mailables-in-the-browser)，因此特发此 PR 回滚操作。

同时 PR #326 仅仅更新了新增功能的翻译内容，其余均未翻译，我将另开一个 PR Fix 该问题。